### PR TITLE
Adds utilities to perform statistical analysis on account and key usage frequencies.

### DIFF
--- a/cmd/substate-cli/main.go
+++ b/cmd/substate-cli/main.go
@@ -40,6 +40,7 @@ func init() {
 		replay.SubstateDumpCommand,
 		replay.GetAddressStatsCommand,
 		replay.GetKeyStatsCommand,
+		replay.GetLocationStatsCommand,
 		dbCommand,
 	}
 	cli.CommandHelpTemplate = flags.CommandHelpTemplate

--- a/cmd/substate-cli/main.go
+++ b/cmd/substate-cli/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Fantom-foundation/go-opera/flags"
 	"github.com/Fantom-foundation/substate-cli/cmd/substate-cli/db"
 	"github.com/Fantom-foundation/substate-cli/cmd/substate-cli/replay"
-	"github.com/Fantom-foundation/go-opera/flags"
 	"github.com/ethereum/go-ethereum/substate"
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -38,9 +38,10 @@ func init() {
 		replay.GetCodeCommand,
 		replay.GetCodeSizeCommand,
 		replay.SubstateDumpCommand,
+		replay.GetAddressStatsCommand,
 		dbCommand,
 	}
-	cli.CommandHelpTemplate = flags.CommandHelpTemplate 
+	cli.CommandHelpTemplate = flags.CommandHelpTemplate
 }
 
 func main() {

--- a/cmd/substate-cli/main.go
+++ b/cmd/substate-cli/main.go
@@ -39,6 +39,7 @@ func init() {
 		replay.GetCodeSizeCommand,
 		replay.SubstateDumpCommand,
 		replay.GetAddressStatsCommand,
+		replay.GetKeyStatsCommand,
 		dbCommand,
 	}
 	cli.CommandHelpTemplate = flags.CommandHelpTemplate

--- a/cmd/substate-cli/replay/address_stats.go
+++ b/cmd/substate-cli/replay/address_stats.go
@@ -1,0 +1,162 @@
+package replay
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/substate"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// record-replay: substate-cli address stats command
+var GetAddressStatsCommand = cli.Command{
+	Action:    getAddressStatsAction,
+	Name:      "address-stats",
+	Usage:     "computes usage statistics of addresss",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		substate.WorkersFlag,
+		substate.SubstateDirFlag,
+		ChainIDFlag,
+	},
+	Description: `
+The substate-cli address-stats command requires two arguments:
+<blockNumFirst> <blockNumLast>
+
+<blockNumFirst> and <blockNumLast> are the first and
+last block of the inclusive range of blocks to be analysed.
+
+Statistics on the usage of addresses are printed to the console.
+`,
+}
+
+type addressStatistics struct {
+	accesses map[common.Address]int
+}
+
+func newStatistics() addressStatistics {
+	return addressStatistics{accesses: map[common.Address]int{}}
+}
+
+func (a *addressStatistics) RegisterAccess(address *common.Address) {
+	a.accesses[*address]++
+}
+
+func (a *addressStatistics) PrintSummary() {
+	var count = len(a.accesses)
+	var sum int64 = 0
+	list := make([]int, 0, len(a.accesses))
+	for _, count := range a.accesses {
+		sum += int64(count)
+		list = append(list, count)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+
+	var prefix_sum = 0
+	for i := range list {
+		list[i] = prefix_sum + list[i]
+		prefix_sum = list[i]
+	}
+
+	fmt.Printf("Reference frequency distribution:\n")
+	for i := 0; i < 100; i++ {
+		fmt.Printf("%d,%d\n", i, list[i*len(list)/100])
+	}
+	fmt.Printf("100,%d\n", list[len(list)-1])
+	fmt.Printf("Number of addresses:        %15d\n", count)
+	fmt.Printf("Number of references:       %15d\n", sum)
+	fmt.Printf("Average references/address: %15.2f\n", float32(sum)/float32(count))
+
+}
+
+func runAddressStatCollector(stats *addressStatistics, src <-chan common.Address, done chan<- int) {
+	for address := range src {
+		stats.RegisterAccess(&address)
+	}
+	close(done)
+}
+
+// collectAddressStats collects statistical information on address usage.
+func collectAccressStats(dest chan<- common.Address, block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
+	// Collect all addresses accessed by this transaction in a set.
+	accessed_addresses := map[common.Address]int{}
+	for address := range st.OutputAlloc {
+		accessed_addresses[address] = 0
+	}
+	for address := range st.InputAlloc {
+		accessed_addresses[address] = 0
+	}
+	// Report accessed addresses to statistics collector.
+	for address := range accessed_addresses {
+		dest <- address
+	}
+	return nil
+}
+
+// getAddressStatsAction collects statistical information on the usage
+// of addresss in transactions.
+func getAddressStatsAction(ctx *cli.Context) error {
+	var err error
+
+	if len(ctx.Args()) != 2 {
+		return fmt.Errorf("substate-cli address-stats command requires exactly 2 arguments")
+	}
+
+	chainID = ctx.Int(ChainIDFlag.Name)
+	fmt.Printf("chain-id: %v\n", chainID)
+	fmt.Printf("git-date: %v\n", gitDate)
+	fmt.Printf("git-commit: %v\n", gitCommit)
+	fmt.Printf("contract-db: %v\n", ContractDB)
+
+	first, ferr := strconv.ParseInt(ctx.Args().Get(0), 10, 64)
+	last, lerr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
+	if ferr != nil || lerr != nil {
+		return fmt.Errorf("substate-cli code: error in parsing parameters: block number not an integer")
+	}
+	if first < 0 || last < 0 {
+		return fmt.Errorf("substate-cli code: error: block number must be greater than 0")
+	}
+	if first > last {
+		return fmt.Errorf("substate-cli code: error: first block has larger number than last block")
+	}
+
+	substate.SetSubstateFlags(ctx)
+	substate.OpenSubstateDBReadOnly()
+	defer substate.CloseSubstateDB()
+
+	// Start Collector.
+	stats := newStatistics()
+	done := make(chan int)
+	addr := make(chan common.Address, 100)
+	go runAddressStatCollector(&stats, addr, done)
+
+	// Create per-transaction task.
+	task := func(block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
+		return collectAccressStats(addr, block, tx, st, taskPool)
+	}
+
+	// Process all transactions in parallel, out-of-order.
+	taskPool := substate.NewSubstateTaskPool("substate-cli code", task, uint64(first), uint64(last), ctx)
+	err = taskPool.Execute()
+	if err != nil {
+		return err
+	}
+
+	// Signal the end of the processed addresses.
+	close(addr)
+
+	// Wait for the collector to finish.
+	for {
+		if _, open := <-done; !open {
+			break
+		}
+	}
+
+	// Print the statistics.
+	fmt.Printf("\n\n----- Summary: -------\n")
+	stats.PrintSummary()
+	fmt.Printf("----------------------\n")
+	return nil
+}

--- a/cmd/substate-cli/replay/address_stats.go
+++ b/cmd/substate-cli/replay/address_stats.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-// record-replay: substate-cli address stats command
+// record-replay: substate-cli address-stats command
 var GetAddressStatsCommand = cli.Command{
 	Action:    getAddressStatsAction,
 	Name:      "address-stats",

--- a/cmd/substate-cli/replay/address_stats.go
+++ b/cmd/substate-cli/replay/address_stats.go
@@ -1,41 +1,37 @@
 package replay
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/substate"
 	"gopkg.in/urfave/cli.v1"
 )
 
-const cli_command = "address-stats"
-
 // record-replay: substate-cli address stats command
 var GetAddressStatsCommand = cli.Command{
 	Action:    getAddressStatsAction,
-	Name:      cli_command,
-	Usage:     "computes usage statistics of addresss",
+	Name:      "address-stats",
+	Usage:     "computes usage statistics of addresses",
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
 		substate.WorkersFlag,
 		substate.SubstateDirFlag,
 		ChainIDFlag,
 	},
-	Description: fmt.Sprintf(`
-The substate-cli %v command requires two arguments:
+	Description: `
+The substate-cli address-stats command requires two arguments:
 <blockNumFirst> <blockNumLast>
 
 <blockNumFirst> and <blockNumLast> are the first and
 last block of the inclusive range of blocks to be analysed.
 
 Statistics on the usage of addresses are printed to the console.
-`, cli_command),
+`,
 }
 
 // getAddressStatsAction collects statistical information on the usage
 // of addresses in transactions.
 func getAddressStatsAction(ctx *cli.Context) error {
-	return getReferenceStatsAction(ctx, cli_command, func(info *TransactionInfo) []common.Address {
+	return getReferenceStatsAction(ctx, "address-stats", func(info *TransactionInfo) []common.Address {
 		addresses := []common.Address{}
 		for address := range info.st.InputAlloc {
 			addresses = append(addresses, address)

--- a/cmd/substate-cli/replay/address_stats.go
+++ b/cmd/substate-cli/replay/address_stats.go
@@ -2,18 +2,18 @@ package replay
 
 import (
 	"fmt"
-	"sort"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/substate"
 	"gopkg.in/urfave/cli.v1"
 )
 
+const cli_command = "address-stats"
+
 // record-replay: substate-cli address stats command
 var GetAddressStatsCommand = cli.Command{
 	Action:    getAddressStatsAction,
-	Name:      "address-stats",
+	Name:      cli_command,
 	Usage:     "computes usage statistics of addresss",
 	ArgsUsage: "<blockNumFirst> <blockNumLast>",
 	Flags: []cli.Flag{
@@ -21,142 +21,28 @@ var GetAddressStatsCommand = cli.Command{
 		substate.SubstateDirFlag,
 		ChainIDFlag,
 	},
-	Description: `
-The substate-cli address-stats command requires two arguments:
+	Description: fmt.Sprintf(`
+The substate-cli %v command requires two arguments:
 <blockNumFirst> <blockNumLast>
 
 <blockNumFirst> and <blockNumLast> are the first and
 last block of the inclusive range of blocks to be analysed.
 
 Statistics on the usage of addresses are printed to the console.
-`,
-}
-
-type addressStatistics struct {
-	accesses map[common.Address]int
-}
-
-func newStatistics() addressStatistics {
-	return addressStatistics{accesses: map[common.Address]int{}}
-}
-
-func (a *addressStatistics) RegisterAccess(address *common.Address) {
-	a.accesses[*address]++
-}
-
-func (a *addressStatistics) PrintSummary() {
-	var count = len(a.accesses)
-	var sum int64 = 0
-	list := make([]int, 0, len(a.accesses))
-	for _, count := range a.accesses {
-		sum += int64(count)
-		list = append(list, count)
-	}
-	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
-
-	var prefix_sum = 0
-	for i := range list {
-		list[i] = prefix_sum + list[i]
-		prefix_sum = list[i]
-	}
-
-	fmt.Printf("Reference frequency distribution:\n")
-	for i := 0; i < 100; i++ {
-		fmt.Printf("%d,%d\n", i, list[i*len(list)/100])
-	}
-	fmt.Printf("100,%d\n", list[len(list)-1])
-	fmt.Printf("Number of addresses:        %15d\n", count)
-	fmt.Printf("Number of references:       %15d\n", sum)
-	fmt.Printf("Average references/address: %15.2f\n", float32(sum)/float32(count))
-
-}
-
-func runAddressStatCollector(stats *addressStatistics, src <-chan common.Address, done chan<- int) {
-	for address := range src {
-		stats.RegisterAccess(&address)
-	}
-	close(done)
-}
-
-// collectAddressStats collects statistical information on address usage.
-func collectAccressStats(dest chan<- common.Address, block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
-	// Collect all addresses accessed by this transaction in a set.
-	accessed_addresses := map[common.Address]int{}
-	for address := range st.OutputAlloc {
-		accessed_addresses[address] = 0
-	}
-	for address := range st.InputAlloc {
-		accessed_addresses[address] = 0
-	}
-	// Report accessed addresses to statistics collector.
-	for address := range accessed_addresses {
-		dest <- address
-	}
-	return nil
+`, cli_command),
 }
 
 // getAddressStatsAction collects statistical information on the usage
-// of addresss in transactions.
+// of addresses in transactions.
 func getAddressStatsAction(ctx *cli.Context) error {
-	var err error
-
-	if len(ctx.Args()) != 2 {
-		return fmt.Errorf("substate-cli address-stats command requires exactly 2 arguments")
-	}
-
-	chainID = ctx.Int(ChainIDFlag.Name)
-	fmt.Printf("chain-id: %v\n", chainID)
-	fmt.Printf("git-date: %v\n", gitDate)
-	fmt.Printf("git-commit: %v\n", gitCommit)
-	fmt.Printf("contract-db: %v\n", ContractDB)
-
-	first, ferr := strconv.ParseInt(ctx.Args().Get(0), 10, 64)
-	last, lerr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
-	if ferr != nil || lerr != nil {
-		return fmt.Errorf("substate-cli code: error in parsing parameters: block number not an integer")
-	}
-	if first < 0 || last < 0 {
-		return fmt.Errorf("substate-cli code: error: block number must be greater than 0")
-	}
-	if first > last {
-		return fmt.Errorf("substate-cli code: error: first block has larger number than last block")
-	}
-
-	substate.SetSubstateFlags(ctx)
-	substate.OpenSubstateDBReadOnly()
-	defer substate.CloseSubstateDB()
-
-	// Start Collector.
-	stats := newStatistics()
-	done := make(chan int)
-	addr := make(chan common.Address, 100)
-	go runAddressStatCollector(&stats, addr, done)
-
-	// Create per-transaction task.
-	task := func(block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
-		return collectAccressStats(addr, block, tx, st, taskPool)
-	}
-
-	// Process all transactions in parallel, out-of-order.
-	taskPool := substate.NewSubstateTaskPool("substate-cli code", task, uint64(first), uint64(last), ctx)
-	err = taskPool.Execute()
-	if err != nil {
-		return err
-	}
-
-	// Signal the end of the processed addresses.
-	close(addr)
-
-	// Wait for the collector to finish.
-	for {
-		if _, open := <-done; !open {
-			break
+	return getReferenceStatsAction(ctx, cli_command, func(info *TransactionInfo) []common.Address {
+		addresses := []common.Address{}
+		for address := range info.st.InputAlloc {
+			addresses = append(addresses, address)
 		}
-	}
-
-	// Print the statistics.
-	fmt.Printf("\n\n----- Summary: -------\n")
-	stats.PrintSummary()
-	fmt.Printf("----------------------\n")
-	return nil
+		for address := range info.st.OutputAlloc {
+			addresses = append(addresses, address)
+		}
+		return addresses
+	})
 }

--- a/cmd/substate-cli/replay/key_stats.go
+++ b/cmd/substate-cli/replay/key_stats.go
@@ -1,6 +1,8 @@
 package replay
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/substate"
 	"gopkg.in/urfave/cli.v1"
@@ -31,7 +33,7 @@ Statistics on the usage of accessed storage locations are printed to the console
 // getKeyStatsAction collects statistical information on the usage
 // of keys (=addresses of storage locations) in transactions.
 func getKeyStatsAction(ctx *cli.Context) error {
-	return getReferenceStatsAction(ctx, "key-stats", func(info *TransactionInfo) []common.Hash {
+	return getReferenceStatsActionWithConsumer(ctx, "key-stats", func(info *TransactionInfo) []common.Hash {
 		keys := []common.Hash{}
 		for _, account := range info.st.InputAlloc {
 			for key := range account.Storage {
@@ -44,5 +46,29 @@ func getKeyStatsAction(ctx *cli.Context) error {
 			}
 		}
 		return keys
-	})
+	}, printKeyValueDistribution)
+}
+
+func printKeyValueDistribution(stats *AccessStatistics[common.Hash]) {
+
+	counts := [common.HashLength + 1]int64{}
+	accesses := [common.HashLength + 1]int64{}
+	for key, value := range stats.accesses {
+		length := getLength(&key)
+		counts[length]++
+		accesses[length] += int64(value)
+	}
+	fmt.Printf("Key length distribution:\n")
+	for i, c := range counts {
+		fmt.Printf("%d, %d, %d\n", i, c, accesses[i])
+	}
+	fmt.Printf("------------------------\n")
+}
+
+func getLength(h *common.Hash) int {
+	res := common.HashLength
+	for res > 0 && h[common.HashLength-res] == 0 {
+		res--
+	}
+	return res
 }

--- a/cmd/substate-cli/replay/key_stats.go
+++ b/cmd/substate-cli/replay/key_stats.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-// record-replay: substate-cli key stats command
+// record-replay: substate-cli key-stats command
 var GetKeyStatsCommand = cli.Command{
 	Action:    getKeyStatsAction,
 	Name:      "key-stats",

--- a/cmd/substate-cli/replay/key_stats.go
+++ b/cmd/substate-cli/replay/key_stats.go
@@ -1,0 +1,48 @@
+package replay
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/substate"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// record-replay: substate-cli key stats command
+var GetKeyStatsCommand = cli.Command{
+	Action:    getKeyStatsAction,
+	Name:      "key-stats",
+	Usage:     "computes usage statistics of accessed storage locations",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		substate.WorkersFlag,
+		substate.SubstateDirFlag,
+		ChainIDFlag,
+	},
+	Description: `
+The substate-cli key-stats command requires two arguments:
+<blockNumFirst> <blockNumLast>
+
+<blockNumFirst> and <blockNumLast> are the first and
+last block of the inclusive range of blocks to be analysed.
+
+Statistics on the usage of accessed storage locations are printed to the console.
+`,
+}
+
+// getKeyStatsAction collects statistical information on the usage
+// of keys (=addresses of storage locations) in transactions.
+func getKeyStatsAction(ctx *cli.Context) error {
+	return getReferenceStatsAction(ctx, "key-stats", func(info *TransactionInfo) []common.Hash {
+		keys := []common.Hash{}
+		for _, account := range info.st.InputAlloc {
+			for key := range account.Storage {
+				keys = append(keys, key)
+			}
+		}
+		for _, account := range info.st.OutputAlloc {
+			for key := range account.Storage {
+				keys = append(keys, key)
+			}
+		}
+		return keys
+	})
+}

--- a/cmd/substate-cli/replay/location_stats.go
+++ b/cmd/substate-cli/replay/location_stats.go
@@ -1,0 +1,82 @@
+package replay
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/substate"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// record-replay: substate-cli location-stats command
+var GetLocationStatsCommand = cli.Command{
+	Action:    getLocationStatsAction,
+	Name:      "location-stats",
+	Usage:     "computes usage statistics of accessed storage locations",
+	ArgsUsage: "<blockNumFirst> <blockNumLast>",
+	Flags: []cli.Flag{
+		substate.WorkersFlag,
+		substate.SubstateDirFlag,
+		ChainIDFlag,
+	},
+	Description: `
+The substate-cli location-stats command requires two arguments:
+<blockNumFirst> <blockNumLast>
+
+<blockNumFirst> and <blockNumLast> are the first and
+last block of the inclusive range of blocks to be analysed.
+
+Statistics on the usage of accessed storage locations are printed to the console.
+`,
+}
+
+type Index[T comparable] struct {
+	index map[T]int
+	mu    sync.Mutex
+}
+
+func (i *Index[T]) Get(value *T) int {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.index == nil {
+		i.index = map[T]int{}
+	}
+	v, present := i.index[*value]
+	if present {
+		return v
+	}
+	v = len(i.index)
+	i.index[*value] = v
+	return v
+}
+
+type Location struct {
+	address_id int
+	key_id     int
+}
+
+// getLocationStatsAction collects statistical information on the usage
+// of storage locations identified by a contracts address and the memory
+// location key.
+func getLocationStatsAction(ctx *cli.Context) error {
+	var address_index Index[common.Address]
+	var key_index Index[common.Hash]
+	return getReferenceStatsAction(ctx, "location-stats", func(info *TransactionInfo) []Location {
+		locations := []Location{}
+		for address, account := range info.st.InputAlloc {
+			address_id := address_index.Get(&address)
+			for key := range account.Storage {
+				key_id := key_index.Get(&key)
+				locations = append(locations, Location{address_id, key_id})
+			}
+		}
+		for address, account := range info.st.OutputAlloc {
+			address_id := address_index.Get(&address)
+			for key := range account.Storage {
+				key_id := key_index.Get(&key)
+				locations = append(locations, Location{address_id, key_id})
+			}
+		}
+		return locations
+	})
+}

--- a/cmd/substate-cli/replay/statistic.go
+++ b/cmd/substate-cli/replay/statistic.go
@@ -41,13 +41,15 @@ func (a *AccessStatistics[T]) PrintSummary() {
 
 	fmt.Printf("Reference frequency distribution:\n")
 	for i := 0; i < 100; i++ {
-		fmt.Printf("%d,%d\n", i, list[i*len(list)/100])
+		fmt.Printf("%d, %d\n", i, list[i*len(list)/100])
 	}
-	fmt.Printf("100,%d\n", list[len(list)-1])
+	fmt.Printf("100, %d\n", list[len(list)-1])
 	fmt.Printf("Number of targets:          %15d\n", count)
 	fmt.Printf("Number of references:       %15d\n", sum)
 	fmt.Printf("Average references/target:  %15.2f\n", float32(sum)/float32(count))
 }
+
+type AccessStatisticsConsumer[T comparable] func(*AccessStatistics[T])
 
 // ----------------------------- Access Statistic Tools ---------------------------------
 
@@ -89,6 +91,12 @@ func collectStats[T comparable](dest chan<- T, extract Extractor[T], block uint6
 // getReferenceStatsAction a generic utility to collect access statistics from recorded
 // substate data.
 func getReferenceStatsAction[T comparable](ctx *cli.Context, cli_command string, extract Extractor[T]) error {
+	return getReferenceStatsActionWithConsumer(ctx, cli_command, extract, func(*AccessStatistics[T]) {})
+}
+
+// getReferenceStatsActionWithConsumer extends the abilitities of the function above by
+// allowing some post-processing to be applied on the collected statistics.
+func getReferenceStatsActionWithConsumer[T comparable](ctx *cli.Context, cli_command string, extract Extractor[T], consume AccessStatisticsConsumer[T]) error {
 	var err error
 
 	if len(ctx.Args()) != 2 {
@@ -149,5 +157,6 @@ func getReferenceStatsAction[T comparable](ctx *cli.Context, cli_command string,
 	fmt.Printf("\n\n----- Summary: -------\n")
 	stats.PrintSummary()
 	fmt.Printf("----------------------\n")
+	consume(&stats)
 	return nil
 }

--- a/cmd/substate-cli/replay/statistic.go
+++ b/cmd/substate-cli/replay/statistic.go
@@ -1,0 +1,153 @@
+package replay
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/substate"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// -------------------- Access Statistic Data Structure --------------------------
+
+type AccessStatistics[T comparable] struct {
+	accesses map[T]int
+}
+
+func newStatistics[T comparable]() AccessStatistics[T] {
+	return AccessStatistics[T]{accesses: map[T]int{}}
+}
+
+func (a *AccessStatistics[T]) RegisterAccess(reference *T) {
+	a.accesses[*reference]++
+}
+
+func (a *AccessStatistics[T]) PrintSummary() {
+	var count = len(a.accesses)
+	var sum int64 = 0
+	list := make([]int, 0, len(a.accesses))
+	for _, count := range a.accesses {
+		sum += int64(count)
+		list = append(list, count)
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+
+	var prefix_sum = 0
+	for i := range list {
+		list[i] = prefix_sum + list[i]
+		prefix_sum = list[i]
+	}
+
+	fmt.Printf("Reference frequency distribution:\n")
+	for i := 0; i < 100; i++ {
+		fmt.Printf("%d,%d\n", i, list[i*len(list)/100])
+	}
+	fmt.Printf("100,%d\n", list[len(list)-1])
+	fmt.Printf("Number of targets:          %15d\n", count)
+	fmt.Printf("Number of references:       %15d\n", sum)
+	fmt.Printf("Average references/target:  %15.2f\n", float32(sum)/float32(count))
+}
+
+// ----------------------------- Access Statistic Tools ---------------------------------
+
+type TransactionInfo struct {
+	block uint64
+	tx    int
+	st    *substate.Substate
+}
+
+type Extractor[T any] func(*TransactionInfo) []T
+
+func runStatCollector[T comparable](stats *AccessStatistics[T], src <-chan T, done chan<- int) {
+	for reference := range src {
+		stats.RegisterAccess(&reference)
+	}
+	close(done)
+}
+
+// collectAddressStats collects statistical information on address usage.
+func collectStats[T comparable](dest chan<- T, extract Extractor[T], block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
+	info := TransactionInfo{
+		block: block,
+		tx:    tx,
+		st:    st,
+	}
+
+	// Collect all references triggered by this transaction.
+	accessed_references := map[T]int{}
+	for _, reference := range extract(&info) {
+		accessed_references[reference] = 0
+	}
+	// Report accessed addresses to statistics collector.
+	for reference := range accessed_references {
+		dest <- reference
+	}
+	return nil
+}
+
+// getReferenceStatsAction a generic utility to collect access statistics from recorded
+// substate data.
+func getReferenceStatsAction[T comparable](ctx *cli.Context, cli_command string, extract Extractor[T]) error {
+	var err error
+
+	if len(ctx.Args()) != 2 {
+		return fmt.Errorf("substate-cli %v command requires exactly 2 arguments", cli_command)
+	}
+
+	chainID = ctx.Int(ChainIDFlag.Name)
+	fmt.Printf("chain-id: %v\n", chainID)
+	fmt.Printf("git-date: %v\n", gitDate)
+	fmt.Printf("git-commit: %v\n", gitCommit)
+	fmt.Printf("contract-db: %v\n", ContractDB)
+
+	first, ferr := strconv.ParseInt(ctx.Args().Get(0), 10, 64)
+	last, lerr := strconv.ParseInt(ctx.Args().Get(1), 10, 64)
+	if ferr != nil || lerr != nil {
+		return fmt.Errorf("substate-cli %v: error in parsing parameters: block number not an integer", cli_command)
+	}
+	if first < 0 || last < 0 {
+		return fmt.Errorf("substate-cli %v: error: block number must be greater than 0", cli_command)
+	}
+	if first > last {
+		return fmt.Errorf("substate-cli %v: error: first block has larger number than last block", cli_command)
+	}
+
+	substate.SetSubstateFlags(ctx)
+	substate.OpenSubstateDBReadOnly()
+	defer substate.CloseSubstateDB()
+
+	// Start Collector.
+	stats := newStatistics[T]()
+	done := make(chan int)
+	refs := make(chan T, 100)
+	go runStatCollector(&stats, refs, done)
+
+	// Create per-transaction task.
+	task := func(block uint64, tx int, st *substate.Substate, taskPool *substate.SubstateTaskPool) error {
+		return collectStats(refs, extract, block, tx, st, taskPool)
+	}
+
+	// Process all transactions in parallel, out-of-order.
+	taskPool := substate.NewSubstateTaskPool(fmt.Sprintf("substate-cli %v", cli_command), task, uint64(first), uint64(last), ctx)
+	err = taskPool.Execute()
+	if err != nil {
+		return err
+	}
+
+	// Signal the end of the processed addresses.
+	close(refs)
+
+	// Wait for the collector to finish.
+	for {
+		if _, open := <-done; !open {
+			break
+		}
+	}
+
+	// Print the statistics.
+	fmt.Printf("\n\n----- Summary: -------\n")
+	stats.PrintSummary()
+	fmt.Printf("----------------------\n")
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,41 @@
 module github.com/Fantom-foundation/substate-cli
 
-go 1.14
+go 1.18
 
 require (
 	github.com/Fantom-foundation/go-opera v1.1.1-rc.2
 	github.com/ethereum/go-ethereum v1.10.8
 	github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	gopkg.in/urfave/cli.v1 v1.20.0
+)
+
+require (
+	github.com/Fantom-foundation/lachesis-base v0.0.0-20220103160934-6b4931c60582 // indirect
+	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
+	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
+	github.com/btcsuite/btcd v0.20.1-beta // indirect
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/deckarep/golang-set v1.7.1 // indirect
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/tsdb v0.10.0 // indirect
+	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
+	github.com/tklauser/go-sysconf v0.3.5 // indirect
+	github.com/tklauser/numcpus v0.2.2 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 )
 
 replace github.com/ethereum/go-ethereum => github.com/Fantom-foundation/go-ethereum-substate v1.0.0


### PR DESCRIPTION
This code adds support for 'address_stat', 'key_stat' and 'location_stat' subcommands to the substate-cli tool. These commands compute statistical summary information on the usage of addresses, keys, and storage locations (=slots).

This change also bumps the minimum Go compiler version to 1.18, since it utilizes generics.