### PR TITLE
Provides three fixes to in-memory stateDB implementation to support all 41 million blocks in the substate DB

### DIFF
--- a/cmd/substate-cli/replay/in_memory_state_db.go
+++ b/cmd/substate-cli/replay/in_memory_state_db.go
@@ -74,8 +74,7 @@ func makeSnapshot(parent *snapshot, id int) *snapshot {
 }
 
 func (db *inMemoryStateDB) CreateAccount(addr common.Address) {
-	//fmt.Printf("Creating account %v\n", addr)
-	//db.state.touched[addr] = 0
+	// ignored
 }
 
 func (db *inMemoryStateDB) SubBalance(addr common.Address, value *big.Int) {
@@ -84,7 +83,6 @@ func (db *inMemoryStateDB) SubBalance(addr common.Address, value *big.Int) {
 	}
 	db.state.touched[addr] = 0
 	db.state.balances[addr] = new(big.Int).Sub(db.GetBalance(addr), value)
-	//fmt.Printf("Decreased balance of %v by %v to %v\n", addr, value, db.state.balances[addr])
 }
 
 func (db *inMemoryStateDB) AddBalance(addr common.Address, value *big.Int) {
@@ -93,7 +91,6 @@ func (db *inMemoryStateDB) AddBalance(addr common.Address, value *big.Int) {
 	}
 	db.state.touched[addr] = 0
 	db.state.balances[addr] = new(big.Int).Add(db.GetBalance(addr), value)
-	//fmt.Printf("Increased balance of %v by %v to %v\n", addr, value, db.state.balances[addr])
 }
 
 func (db *inMemoryStateDB) GetBalance(addr common.Address) *big.Int {
@@ -127,7 +124,6 @@ func (db *inMemoryStateDB) GetNonce(addr common.Address) uint64 {
 func (db *inMemoryStateDB) SetNonce(addr common.Address, value uint64) {
 	db.state.touched[addr] = 0
 	db.state.nonces[addr] = value
-	debug("Updated nonce of %v\n", addr)
 }
 
 func (db *inMemoryStateDB) GetCodeHash(addr common.Address) common.Hash {
@@ -193,19 +189,15 @@ func (db *inMemoryStateDB) GetState(addr common.Address, key common.Hash) common
 }
 
 func (db *inMemoryStateDB) SetState(addr common.Address, key common.Hash, value common.Hash) {
-	//fmt.Printf("SSTORE: %v %v - %v\n", addr, key, value)
 	db.state.touched[addr] = 0
 	db.state.storage[slot{addr, key}] = value
 }
 
 func (db *inMemoryStateDB) Suicide(addr common.Address) bool {
-	//fmt.Printf("Suicide called for %v\n", addr)
-	db.state.touched[addr] = 0
 	db.state.suicided[addr] = 0
 	return true
 }
 func (db *inMemoryStateDB) HasSuicided(addr common.Address) bool {
-	//fmt.Printf("Has suicided called for %v\n", addr)
 	for state := db.state; state != nil; state = state.parent {
 		_, exists := state.suicided[addr]
 		if exists {
@@ -369,6 +361,7 @@ func (db *inMemoryStateDB) GetEffects() substate.SubstateAlloc {
 func (db *inMemoryStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
 	// Use the pre-alloc ...
 	res := *db.alloc
+
 	// ... and extend with effects
 	for key, value := range db.GetEffects() {
 		entry, exists := res[key]

--- a/cmd/substate-cli/replay/in_memory_state_db.go
+++ b/cmd/substate-cli/replay/in_memory_state_db.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/substate"
 )
 
@@ -128,11 +127,11 @@ func (db *inMemoryStateDB) GetNonce(addr common.Address) uint64 {
 func (db *inMemoryStateDB) SetNonce(addr common.Address, value uint64) {
 	db.state.touched[addr] = 0
 	db.state.nonces[addr] = value
+	debug("Updated nonce of %v\n", addr)
 }
 
 func (db *inMemoryStateDB) GetCodeHash(addr common.Address) common.Hash {
 	return getHash(addr, db.GetCode(addr))
-	return crypto.Keccak256Hash(db.GetCode(addr))
 }
 
 func (db *inMemoryStateDB) GetCode(addr common.Address) []byte {
@@ -385,5 +384,13 @@ func (db *inMemoryStateDB) GetSubstatePostAlloc() substate.SubstateAlloc {
 			entry.Storage[key] = value
 		}
 	}
+
+	for key := range res {
+		if db.HasSuicided(key) {
+			delete(res, key)
+			continue
+		}
+	}
+
 	return res
 }

--- a/cmd/substate-cli/replay/in_memory_state_db.go
+++ b/cmd/substate-cli/replay/in_memory_state_db.go
@@ -195,6 +195,7 @@ func (db *inMemoryStateDB) SetState(addr common.Address, key common.Hash, value 
 
 func (db *inMemoryStateDB) Suicide(addr common.Address) bool {
 	db.state.suicided[addr] = 0
+	db.state.balances[addr] = new(big.Int) // Apparently when you die all your money is gone.
 	return true
 }
 func (db *inMemoryStateDB) HasSuicided(addr common.Address) bool {


### PR DESCRIPTION
With those fixes
 - no record of sucided accounts are reported as changes
 - sucided accounts are robbed of their money, and
 - the access list feature required for identifying hot and cold storage locations is added

With those fixes, a full replayer run with all 41 million blocks finished in 1h 58minutes without errors.