### PR TITLE
Add commit to stateDB interface

### DIFF
--- a/state/in_memory_state_db.go
+++ b/state/in_memory_state_db.go
@@ -17,6 +17,7 @@ type StateDB interface {
 	Prepare(common.Hash, int)
 	Finalise(bool)
 	IntermediateRoot(deleteEmptyObjects bool) common.Hash
+	Commit(bool) (common.Hash, error)
 	GetLogs(common.Hash, common.Hash) []*types.Log
 	GetSubstatePostAlloc() substate.SubstateAlloc
 }
@@ -317,6 +318,10 @@ func (db *inMemoryStateDB) Finalise(bool) {
 func (db *inMemoryStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 	panic("not implemented")
 	return common.Hash{}
+}
+
+func (db *inMemoryStateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
+	return common.Hash{}, nil
 }
 
 func collectLogs(s *snapshot) []*types.Log {


### PR DESCRIPTION
For Aida project. Support stateDB Commit for in-memory implementation.