### PR TITLE
Adapt inMemoryStateDB to be able to replay to 50M blocks

### DIFF
--- a/cmd/substate-cli/replay/replay.go
+++ b/cmd/substate-cli/replay/replay.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+
 	//"github.com/ethereum/go-ethereum/core/state"
 	"github.com/Fantom-foundation/go-opera/evmcore"
 	"github.com/Fantom-foundation/go-opera/opera"
@@ -137,7 +138,7 @@ func replayTask(config ReplayConfig, block uint64, tx int, recording *substate.S
 
 	var statedb state.StateDB
 	if config.use_in_memory_db {
-		statedb = state.MakeInMemoryStateDB(&inputAlloc)
+		statedb = state.MakeInMemoryStateDB(&inputAlloc, block)
 	} else {
 		statedb = state.MakeOffTheChainStateDB(inputAlloc)
 	}


### PR DESCRIPTION
Affects only inMemoryStateDB, not normal StateDB implementation
This solution is not optimal as it contains hardcoded block number, but this was the way, how to process all blocks to 50M with option -faststatedb which uses inMemoryStateDB which doesn't implement journal of normal and dirty changes. So it is hard to recognise reverted changes of touched accounts and slots.